### PR TITLE
Add support for multiValueQueryStringParameters

### DIFF
--- a/packages/laconia-event/src/apigateway/ApiGatewayEvent.js
+++ b/packages/laconia-event/src/apigateway/ApiGatewayEvent.js
@@ -12,7 +12,8 @@ module.exports = class ApiGatewayEvent {
     apiGatewayEvent.params = Object.assign(
       {},
       event.pathParameters,
-      event.queryStringParameters
+      event.queryStringParameters,
+      event.multiValueQueryStringParameters
     );
     return apiGatewayEvent;
   }

--- a/packages/laconia-event/test/apigateway/ApiGatewayEvent.spec.js
+++ b/packages/laconia-event/test/apigateway/ApiGatewayEvent.spec.js
@@ -54,6 +54,14 @@ describe("ApiGatewayEvent", () => {
     );
   });
 
+  it("should convert multiValueQueryStringParameters into params", async () => {
+    event.multiValueQueryStringParameters = { queryParam1: ["1", "2"] };
+    const apiGatewayEvent = await ApiGatewayEvent.fromRaw(event);
+    expect(apiGatewayEvent.params).toEqual(
+      expect.objectContaining({ queryParam1: ["1", "2"] })
+    );
+  });
+
   it("should be able to retrieve headers with node.js canonical format", async () => {
     const apiGatewayEvent = await ApiGatewayEvent.fromRaw(event);
     expect(apiGatewayEvent.headers["content-type"]).toEqual(


### PR DESCRIPTION
https://aws.amazon.com/blogs/compute/support-for-multi-value-parameters-in-amazon-api-gateway/
https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html

Currently I'm not able to use multi-value query string parameters with this adapter. I was going to just open an issue but it is a simple change.