### PR TITLE
feat: allow dependencies objects

### DIFF
--- a/packages/laconia-core/src/index.d.ts
+++ b/packages/laconia-core/src/index.d.ts
@@ -24,9 +24,11 @@ declare namespace laconia {
     (laconiaContext: Context): void;
   }
 
+  type LaconiaDependency<Context, Dependencies> = LaconiaFactory<Context, Dependencies> | Partial<LaconiaContext>
+
   interface LaconiaHandler extends Handler {
     register<Context extends LaconiaContext, Dependencies>(
-      factory: LaconiaFactory<Context, Dependencies> | LaconiaFactory<Context, Dependencies>[],
+      factory: LaconiaDependency<Context, Dependencies> | LaconiaDependency<Context, Dependencies>[],
       options?: FactoryOptions
     ): this;
     register<Context extends LaconiaContext, Dependencies>(

--- a/packages/laconia-core/src/laconia.js
+++ b/packages/laconia-core/src/laconia.js
@@ -39,12 +39,16 @@ module.exports = app => {
   };
 
   const registerMultiple = (factory, options = {}) => {
+    const makeFactory = factory =>
+      typeof factory === "function" ? factory : () => factory;
+
     if (Array.isArray(factory)) {
-      factory.forEach(f => checkFunction("register", f));
-      laconiaContext.registerFactories(factory, options.cache);
+      factory.forEach(f => checkFunctionOrObject("register", f));
+      const factories = factory.map(makeFactory);
+      laconiaContext.registerFactories(factories, options.cache);
     } else {
-      checkFunction("register", factory);
-      laconiaContext.registerFactory(factory, options.cache);
+      checkFunctionOrObject("register", factory);
+      laconiaContext.registerFactory(makeFactory(factory), options.cache);
     }
   };
 
@@ -56,6 +60,8 @@ module.exports = app => {
 
       if (typeof factory === "string") {
         registerSingle(factory, optionsOrFactory, options);
+      } else if (typeof factory === "object") {
+        registerMultiple(factory, optionsOrFactory);
       } else {
         registerMultiple(factory, optionsOrFactory);
       }

--- a/packages/laconia-core/src/laconia.js
+++ b/packages/laconia-core/src/laconia.js
@@ -1,14 +1,6 @@
 const AWS = require("aws-sdk");
 const CoreLaconiaContext = require("./CoreLaconiaContext");
-
-const checkFunction = (functionName, argument) => {
-  if (typeof argument !== "function")
-    throw new TypeError(
-      `${functionName}() expects to be passed a function, you passed: ${JSON.stringify(
-        argument
-      )}`
-    );
-};
+const { checkFunction, checkFunctionOrObject } = require("./typeChecking");
 
 const awsInstances = {
   lambda: new AWS.Lambda(),

--- a/packages/laconia-core/src/typeChecking.js
+++ b/packages/laconia-core/src/typeChecking.js
@@ -1,0 +1,21 @@
+const checkFunction = (functionName, argument) => {
+  if (typeof argument !== "function")
+    throw new TypeError(
+      `${functionName}() expects to be passed a function, you passed: ${JSON.stringify(
+        argument
+      )}`
+    );
+};
+const checkFunctionOrObject = (functionName, argument) => {
+  if (typeof argument !== "function" && typeof argument !== "object")
+    throw new TypeError(
+      `${functionName}() expects to be passed a function or object, you passed: ${JSON.stringify(
+        argument
+      )}`
+    );
+};
+
+module.exports = {
+  checkFunction,
+  checkFunctionOrObject
+};

--- a/packages/laconia-core/test/laconia.spec.js
+++ b/packages/laconia-core/test/laconia.spec.js
@@ -169,10 +169,25 @@ describe("laconia", () => {
         expect(factory).toHaveBeenCalledTimes(2);
       });
 
-      it("should throw an error when the factory is not a function", async () => {
-        expect(() => laconia(jest.fn()).register({ foo: "bar" })).toThrow(
+      it("should be able to add an dependencies object by calling 'register'", async () => {
+        const app = jest.fn();
+        await laconia(app)
+          .register({ foo: "bar" })
+          .register({ boo: "baz" })(...handlerArgs);
+
+        expect(app).toBeCalledWith(
+          expect.any(Object),
+          expect.objectContaining({
+            foo: "bar",
+            boo: "baz"
+          })
+        );
+      });
+
+      it("should throw an error when the factory is not a function or object", async () => {
+        expect(() => laconia(jest.fn()).register(23)).toThrow(
           new TypeError(
-            'register() expects to be passed a function, you passed: {"foo":"bar"}'
+            "register() expects to be passed a function or object, you passed: 23"
           )
         );
       });
@@ -208,6 +223,21 @@ describe("laconia", () => {
         );
       });
 
+      it("should return instances created by the array of objects", async () => {
+        const app = jest.fn();
+        await laconia(app).register([{ foo: "bar", boo: "baz" }])(
+          ...handlerArgs
+        );
+
+        expect(app).toBeCalledWith(
+          expect.any(Object),
+          expect.objectContaining({
+            foo: "bar",
+            boo: "baz"
+          })
+        );
+      });
+
       it("should cache all by default", async () => {
         const handler = await laconia(jest.fn()).register([factory1, factory2]);
         await handler(...handlerArgs);
@@ -233,10 +263,10 @@ describe("laconia", () => {
         expect(factory2).toHaveBeenCalledTimes(2);
       });
 
-      it("should throw an error when the factory is not a function", async () => {
-        expect(() => laconia(jest.fn()).register([{ foo: "bar" }])).toThrow(
+      it("should throw an error when the factory is not a function or object", async () => {
+        expect(() => laconia(jest.fn()).register([23])).toThrow(
           new TypeError(
-            'register() expects to be passed a function, you passed: {"foo":"bar"}'
+            "register() expects to be passed a function or object, you passed: 23"
           )
         );
       });
@@ -479,10 +509,10 @@ describe("laconia/async", () => {
         expect(factory).toHaveBeenCalledTimes(2);
       });
 
-      it("should throw an error when the factory is not a function", async () => {
-        expect(() => laconia(jest.fn()).register({ foo: "bar" })).toThrow(
+      it("should throw an error when the factory is not a function or object", async () => {
+        expect(() => laconia(jest.fn()).register(23)).toThrow(
           new TypeError(
-            'register() expects to be passed a function, you passed: {"foo":"bar"}'
+            "register() expects to be passed a function or object, you passed: 23"
           )
         );
       });
@@ -543,10 +573,10 @@ describe("laconia/async", () => {
         expect(factory2).toHaveBeenCalledTimes(2);
       });
 
-      it("should throw an error when the factory is not a function", async () => {
-        expect(() => laconia(jest.fn()).register([{ foo: "bar" }])).toThrow(
+      it("should throw an error when the factory is not a function or object", async () => {
+        expect(() => laconia(jest.fn()).register([23])).toThrow(
           new TypeError(
-            'register() expects to be passed a function, you passed: {"foo":"bar"}'
+            "register() expects to be passed a function or object, you passed: 23"
           )
         );
       });

--- a/packages/laconia-core/test/types/index.ts
+++ b/packages/laconia-core/test/types/index.ts
@@ -29,6 +29,27 @@ laconia(app)
   .register(() => ({ someKey: "value" }), {})
   .register(() => ({ someKey: "value" }), {})
   .register("someKey", () => "value", {})
+  .register({
+    someKey: "value"
+  })
+  .register([{ someKey: "value" }, { someKey: "value" }])
+  .register([
+    { someKey: "value" },
+    () => ({
+      someKey: "value"
+    })
+  ])
+  .register(
+    {
+      someKey: "value"
+    },
+    {
+      cache: {
+        enabled: false,
+        maxAge: 1000
+      }
+    }
+  )
   .register(() => ({ someKey: "value" }), {
     cache: {
       enabled: false,


### PR DESCRIPTION
Fixes #392

## ✨ Description
<!-- Explain what happens in this PR -->

Implements functionality to allow registering dependencies without the need for a factory function.

Whilst factory functions are great, and Laconia excels at the caching of dependencies to keep performance of successive lambda invocations high, sometimes you might prefer to simply pass in an object, rather than a factory function.

This means you can now do:

```js
export const handler = laconia(app).register({
	productsTable,
	usersTable
});
```

This is in addition to still allowing all of the other signatures for the `.register()` function. I was quite surprised there's so many, so here's a quick overview of what I learned are valid signatures:

```js
// previous valid patterns
laconia(app).register(() => ({ productsTable, usersTable });
laconia(app).register("products", productsTable);
laconia(app).register([() => ({ productsTable }), () => ({ usersTable })]);

// newly added patterns
laconia(app).register({ productsTable, usersTable });
laconia(app).register([{ productsTable }, { usersTable }]);

// of course all chainable, as per usual:
laconia(app).register({ productsTable }).register({ usersTable });
```


## 🕵 Background
<!-- Explain why this change is being made -->

This was proposed in #392 - and feels like it makes the library a lot more user friendly to use. 
Thanks @hugosenari for the suggestion!

It's a breaking change, so doing it as part of the v2 release seemed appropriate.

## 📝 Resources
<!-- Add notes and documentation links where relevant -->

- #392
- #987 
